### PR TITLE
fix: set deleteSnippet keymap instead of delete

### DIFF
--- a/lua/scissors/edit-popup.lua
+++ b/lua/scissors/edit-popup.lua
@@ -60,7 +60,7 @@ local function setupPopupKeymaps(bufnr, winnr, mode, snip, prefixBodySep)
 	vim.cmd.cnoreabbrev("<buffer> write ScissorsSave")
 	vim.api.nvim_buf_create_user_command(bufnr, "ScissorsSave", confirmChanges, {})
 
-	keymap("n", mappings.delete, function()
+	keymap("n", mappings.deleteSnippet, function()
 		if mode == "new" then
 			u.notify("Cannot delete a snippet that has not been saved yet.", "warn")
 			return


### PR DESCRIPTION
Fixes an error when opening the popup that happens unless you set the `delete` keymap in the config. 

## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  README.md (the `.txt` file is auto-generated and does not need to be modified).
- [x] Used conventional commits keywords.
