### PR TITLE
feat: add ability to prefill selection when used as command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,23 +112,18 @@ require("luasnip.loaders.from_vscode").lazy_load { paths = { "path/to/your/snipp
 > done by snippet engines like [LuaSnip](https://github.com/L3MON4D3/LuaSnip).
 
 ## Usage
-The plugin provides two commands, `addNewSnippet` and `editSnippet`. Here is the
-code to create keymaps for them:
+The plugin provides two commands, `:ScissorsAddSnippet` and
+`ScissorsEditSnippet`. You can pass range to `:ScissorsAddSnippet` command to
+prefill snippet body (e.g. `:'<,'>ScissorsAddSnippet`, `:3ScissorsAddSnippet`, etc).
+
+Also, plugin's API provides two functions `addNewSnippet` and `editSnippet`.
+Here is the code to create keymaps for them:
 
 ```lua
-vim.keymap.set("n", "<leader>se", require("scissors").editSnippet)
+vim.keymap.set("n", "<leader>se", function() require("scissors").editSnippet() end)
 
 -- When used in visual mode prefills the selection as body.
-vim.keymap.set({ "n", "x" }, "<leader>sa", require("scissors").addNewSnippet)
-```
-
-And here is the code to create user commands:
-
-```lua
-vim.api.nvim_create_user_command('SnippetEdit', require("scissors").editSnippet, {})
-
--- When used in visual mode (or range is supplied) prefills the selection as body.
-vim.api.nvim_create_user_command('SnippetAdd', require("scissors").addNewSnippet, { range = true })
+vim.keymap.set({ "n", "x" }, "<leader>sa", function() require("scissors").addNewSnippet() end)
 ```
 
 > [!TIP]

--- a/README.md
+++ b/README.md
@@ -116,10 +116,19 @@ The plugin provides two commands, `addNewSnippet` and `editSnippet`. Here is the
 code to create keymaps for them:
 
 ```lua
-vim.keymap.set("n", "<leader>se", function() require("scissors").editSnippet() end)
+vim.keymap.set("n", "<leader>se", require("scissors").editSnippet)
 
 -- When used in visual mode prefills the selection as body.
-vim.keymap.set({ "n", "x" }, "<leader>sa", function() require("scissors").addNewSnippet() end)
+vim.keymap.set({ "n", "x" }, "<leader>sa", require("scissors").addNewSnippet)
+```
+
+And here is the code to create user commands:
+
+```lua
+vim.api.nvim_create_user_command('SnippetEdit', require("scissors").editSnippet, {})
+
+-- When used in visual mode (or range is supplied) prefills the selection as body.
+vim.api.nvim_create_user_command('SnippetAdd', require("scissors").addNewSnippet, { range = true })
 ```
 
 > [!TIP]

--- a/lua/scissors/config.lua
+++ b/lua/scissors/config.lua
@@ -59,7 +59,11 @@ function M.setupPlugin(userConfig)
 	if userConfig.snippetDir then userConfig.snippetDir = vim.fs.normalize(userConfig.snippetDir) end
 
 	---@deprecated keymap.delete
-	if userConfig.editSnippetPopup and userConfig.editSnippetPopup.keymaps and userConfig.editSnippetPopup.keymaps.delete then ---@diagnostic disable-line: undefined-field
+	if
+		userConfig.editSnippetPopup
+		and userConfig.editSnippetPopup.keymaps
+		and userConfig.editSnippetPopup.keymaps.delete ---@diagnostic disable-line: undefined-field
+	then
 		local notify = require("scissors.utils").notify
 		notify("`keymap.delete` is deprecated. Use `keymap.deleteSnippet instead.", "warn")
 		userConfig.editSnippetPopup.keymaps.deleteSnippet = userConfig.editSnippetPopup.keymaps.delete ---@diagnostic disable-line: undefined-field

--- a/lua/scissors/init.lua
+++ b/lua/scissors/init.lua
@@ -55,7 +55,8 @@ function M.editSnippet()
 	picker.selectSnippet(allSnippets)
 end
 
-function M.addNewSnippet()
+function M.addNewSnippet(args)
+	args = args or {}
 	local snippetDir = require("scissors.config").config.snippetDir
 
 	local vb = require("scissors.vscode-format.validate-bootstrap")
@@ -75,6 +76,10 @@ function M.addNewSnippet()
 		local endRow, endCol = unpack(vim.api.nvim_buf_get_mark(0, ">"))
 		endCol = mode:find("V") and -1 or (endCol + 1)
 		bodyPrefill = vim.api.nvim_buf_get_text(0, startRow - 1, startCol, endRow - 1, endCol, {})
+		bodyPrefill = u.dedent(bodyPrefill)
+	elseif type(args.range) == "number" and args.range > 0 then
+		local endRow = args.range == 2 and args.line2 or args.line1
+		bodyPrefill = vim.api.nvim_buf_get_text(0, args.line1 - 1, 0, endRow - 1, -1, {})
 		bodyPrefill = u.dedent(bodyPrefill)
 	end
 

--- a/plugin/user-commands.lua
+++ b/plugin/user-commands.lua
@@ -1,0 +1,11 @@
+vim.api.nvim_create_user_command(
+	"ScissorsAddSnippet",
+	function(args) require("scissors").addNewSnippet(args) end,
+	{ desc = "Add new snippet", range = true }
+)
+
+vim.api.nvim_create_user_command(
+	"ScissorsEditSnippet",
+	function() require("scissors").editSnippet() end,
+	{ desc = "Edit existing snippet" }
+)


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  README.md (the `.txt` file is auto-generated and does not need to be modified).
- [x] Used conventional commits keywords.
