### PR TITLE
improv(editPopup): common ignorable bufname for snippet editor

### DIFF
--- a/lua/scissors/edit-popup.lua
+++ b/lua/scissors/edit-popup.lua
@@ -163,7 +163,7 @@ function M.editInPopup(snip, mode)
 	local bufName, winTitle
 	if mode == "update" then
 		local displayName = u.snipDisplayName(snip)
-		bufName = ("Edit Snippet %s"):format(displayName)
+		bufName = ("Edit Snippet %q"):format(displayName)
 		winTitle = (" Editing %q [%s] "):format(displayName, nameOfSnippetFile)
 	else
 		bufName = "New Snippet"

--- a/lua/scissors/edit-popup.lua
+++ b/lua/scissors/edit-popup.lua
@@ -162,8 +162,9 @@ function M.editInPopup(snip, mode)
 
 	local bufName, winTitle
 	if mode == "update" then
-		bufName = u.snipDisplayName(snip)
-		winTitle = (" Editing %q [%s] "):format(bufName, nameOfSnippetFile)
+		local displayName = u.snipDisplayName(snip)
+		bufName = ("Edit Snippet %s"):format(displayName)
+		winTitle = (" Editing %q [%s] "):format(displayName, nameOfSnippetFile)
 	else
 		bufName = "New Snippet"
 		winTitle = (" New Snippet in %q "):format(nameOfSnippetFile)


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  README.md (the `.txt` file is auto-generated and does not need to be modified).
- [x] Used conventional commits keywords.

I'd like to prevent my statusline plugin (heirline) to not display a winbar onto the snippet editor.

At the moment this is already implemented for "New Snippets" [](https://github.com/chrisgrieser/nvim-scissors/blob/e9f395ccb44c3d36cc59d0731181ae202e3055af/lua/scissors/edit-popup.lua#L168), but I dont really find any other reasonable key to leverage on (as buftype "nofile" is shared with most of plugin buffers and filetype is not really an option)

![photo_2024-05-30_20-38-22](https://github.com/chrisgrieser/nvim-scissors/assets/44092476/c059fc58-ad47-4b5d-a057-fdc1c1c0e579)
