### PR TITLE
fix: add build to Lazy LuaSnip declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,14 @@ Automagical editing and creation of snippets.
 ```lua
 -- lazy.nvim
 {
-	"chrisgrieser/nvim-scissors",
-	dependencies = { "nvim-telescope/telescope.nvim", "L3MON4D3/LuaSnip" }, 
+	'chrisgrieser/nvim-scissors',
+	dependencies = {
+		'nvim-telescope/telescope.nvim',
+		{
+			'L3MON4D3/LuaSnip',
+			build = 'make install_jsregexp',
+		},
+	},
 	opts = {
 		snippetDir = "path/to/your/snippetFolder",
 	} 


### PR DESCRIPTION
I got errors when listing 'L3M0N4D3/LuaSnip' as a dependency without also including the build explicitly. This change to my lazy plugin .lua file cleared those errors up.

## Checklist
- [ ] Used only camelCase variable names.
- [ ] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).
