### PR TITLE
fix: layout_strategy telescope option

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ require("scissors").setup {
 
 		-- accepts the common telescope picker config
 		opts = {
-			layout_strategies = "horizontal",
+			layout_strategy = "horizontal",
 			layout_config = {
 				horizontal = { width = 0.9 },
 				preview_width = 0.6,

--- a/doc/nvim-scissors.txt
+++ b/doc/nvim-scissors.txt
@@ -310,7 +310,7 @@ The `.setup()` call is optional.
     
             -- accepts the common telescope picker config
             opts = {
-                layout_strategies = "horizontal",
+                layout_strategy = "horizontal",
                 layout_config = {
                     horizontal = { width = 0.9 },
                     preview_width = 0.6,

--- a/lua/scissors/config.lua
+++ b/lua/scissors/config.lua
@@ -27,7 +27,7 @@ local defaultConfig = {
 
 		-- accepts the common telescope picker config
 		opts = {
-			layout_strategies = "horizontal",
+			layout_strategy = "horizontal",
 			layout_config = {
 				horizontal = { width = 0.9 },
 				preview_width = 0.6,


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).

The `layout_strategy` option in telescope options was incorrectly written as `layout_strategies`. Fixed the typo in README and docs and config.