### PR TITLE
feat: allow choosing vim.ui.select as picker, when telescope is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,10 @@ require("scissors").setup {
 		},
 	},
 
+	-- choose which picker to use to select snippets to edit
+	---@type "telescope"|"vim.ui.select"
+	picker = "telescope",
+
 	-- `none` writes as a minified json file using `vim.encode.json`.
 	-- `yq`/`jq` ensure formatted & sorted json files, which is relevant when
 	-- you version control your snippets. To use a custom formatter, set to a

--- a/doc/nvim-scissors.txt
+++ b/doc/nvim-scissors.txt
@@ -317,7 +317,11 @@ The `.setup()` call is optional.
                 },
             },
         },
-    
+
+	-- choose which picker to usea to select snippets to edit
+	---@type "telescope"|"vim.ui.select"
+	picker = "telescope",
+
         -- `none` writes as a minified json file using `vim.encode.json`.
         -- `yq`/`jq` ensure formatted & sorted json files, which is relevant when
         -- you version control your snippets. To use a custom formatter, set to a

--- a/lua/scissors/2-picker/picker-choice.lua
+++ b/lua/scissors/2-picker/picker-choice.lua
@@ -9,7 +9,8 @@ function M.selectSnippet(allSnippets)
 	-- INFO not using ternary to pass variable into `require`, since that
 	-- prevents the LSP from picking up references
 	local hasTelescope, _ = pcall(require, "telescope")
-	if hasTelescope then
+	local picker = require("scissors.config").config.picker
+	if hasTelescope and picker == "telescope" then
 		require("scissors.2-picker.telescope").selectSnippet(allSnippets, prompt)
 	else
 		require("scissors.2-picker.vim-ui-select").selectSnippet(allSnippets, prompt)
@@ -34,7 +35,8 @@ function M.addSnippet(allSnipFiles, bodyPrefill)
 	local prompt = vim.trim(icon .. " Select file for new snippet: ")
 
 	local hasTelescope, _ = pcall(require, "telescope")
-	if hasTelescope then
+	local picker = require("scissors.config").config.picker
+	if hasTelescope and picker == "telescope" then
 		-- stylua: ignore
 		require("scissors.2-picker.telescope").addSnippet(allSnipFiles, fileDisplay, prompt, bodyPrefill)
 	else

--- a/lua/scissors/config.lua
+++ b/lua/scissors/config.lua
@@ -35,6 +35,10 @@ local defaultConfig = {
 		},
 	},
 
+	-- choose which picker to use
+	---@type "telescope"|"vim.ui.select"
+	picker = "telescope",
+
 	-- `none` writes as a minified json file using `vim.encode.json`.
 	-- `yq`/`jq` ensure formatted & sorted json files, which is relevant when
 	-- you version control your snippets. To use a custom formatter, set to a

--- a/lua/scissors/config.lua
+++ b/lua/scissors/config.lua
@@ -35,7 +35,7 @@ local defaultConfig = {
 		},
 	},
 
-	-- choose which picker to use
+	-- choose which picker to use to select snippets to edit
 	---@type "telescope"|"vim.ui.select"
 	picker = "telescope",
 


### PR DESCRIPTION
While debugging some issues with telescope, I wanted to just use the `vim.ui.select` picker instead, and was unable to if I had telescope installed.

This PR allows selecting the picker, and works even if `telescope` is installed but you want to use `vim.ui.select` instead.

## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).
