### PR TITLE
fix: enable setting layout_strategy that isnt horizontal or cursor

### DIFF
--- a/lua/scissors/config.lua
+++ b/lua/scissors/config.lua
@@ -59,6 +59,12 @@ M.config = defaultConfig -- in case user does not call `setup`
 function M.setupPlugin(userConfig)
 	M.config = vim.tbl_deep_extend("force", defaultConfig, userConfig or {})
 
+	-- preview_width is only supported by `horizontal` and `cursor` strategies
+	local strategy = M.config.telescope.opts.layout_strategy
+	if not (strategy == "horizontal" or strategy == "cursor") then
+		M.config.telescope.opts.layout_config.preview_width = nil
+	end
+
 	-- normalizing relevant as it expands `~` to the home directory
 	M.config.snippetDir = vim.fs.normalize(M.config.snippetDir)
 


### PR DESCRIPTION
Removes incompatible `preview_width` option from telescope options when using an incompatible `layout_strategy`.

Closes #28.

## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).
