### PR TITLE
feat: support for snacks.nvim picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Automagical editing and creation of snippets.
 - Optional JSON-formatting and sorting of the snippet file. ([Useful when
   version-controlling your snippet
   collection](#version-controlling-snippets--snippet-file-formatting).)
-- Snippet/file selection via `telescope` or `vim.ui.select`.
+- Snippet/file selection via `telescope`, `snacks`, or `vim.ui.select`.
 - Automatic bootstrapping of the snippet folder or new snippet files if needed.
 - Supports only [VSCode-style
   snippets](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_create-your-own-snippets).
@@ -78,10 +78,10 @@ Automagical editing and creation of snippets.
 - nvim 0.10+
 - Snippets saved in the [VSCode-style snippet
   format](#introduction-to-the-vscode-style-snippet-format).
-- [telescope](https://github.com/nvim-telescope/telescope.nvim) OR
+- [telescope](https://github.com/nvim-telescope/telescope.nvim) or [snacks.nvim](https://github.com/folke/snacks.nvim) OR
   ([dressing.nvim](http://github.com/stevearc/dressing.nvim) AND
   [fzf-lua](https://github.com/ibhagwan/fzf-lua)).
-  * Note that snippet previews only work when using `telescope`.
+  * Note that snippet previews only work when using `telescope` or `snacks`.
 - A snippet engine that can load VSCode-style snippets, such as:
   * [LuaSnip](https://github.com/L3MON4D3/LuaSnip)
   * [mini.snippets](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-snippets.md)
@@ -100,7 +100,7 @@ Automagical editing and creation of snippets.
 -- lazy.nvim
 {
 	"chrisgrieser/nvim-scissors",
-	dependencies = "nvim-telescope/telescope.nvim", 
+	dependencies = "nvim-telescope/telescope.nvim", -- if using telescope
 	opts = {
 		snippetDir = "path/to/your/snippetFolder",
 	} 
@@ -109,7 +109,7 @@ Automagical editing and creation of snippets.
 -- packer
 use {
 	"chrisgrieser/nvim-scissors",
-	dependencies = "nvim-telescope/telescope.nvim", 
+	dependencies = "nvim-telescope/telescope.nvim", -- if using telescope
 	config = function()
 		require("scissors").setup ({
 			snippetDir = "path/to/your/snippetFolder",
@@ -310,6 +310,9 @@ require("scissors").setup {
 	},
 }
 ```
+> Note that you can configure the `snacks` picker through `snacks.nvim`'s picker configuration.
+> See the [snacks docs](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md) for more
+> information.
 
 ## Cookbook & FAQ
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Automagical editing and creation of snippets.
 - nvim 0.10+
 - Snippets saved in the [VSCode-style snippet
   format](#introduction-to-the-vscode-style-snippet-format).
-- [telescope](https://github.com/nvim-telescope/telescope.nvim) or 
+- [telescope](https://github.com/nvim-telescope/telescope.nvim) or
 [snacks.nvim](https://github.com/folke/snacks.nvim) OR
   ([dressing.nvim](http://github.com/stevearc/dressing.nvim) AND
   [fzf-lua](https://github.com/ibhagwan/fzf-lua)).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Automagical editing and creation of snippets.
 - nvim 0.10+
 - Snippets saved in the [VSCode-style snippet
   format](#introduction-to-the-vscode-style-snippet-format).
-- [telescope](https://github.com/nvim-telescope/telescope.nvim) or [snacks.nvim](https://github.com/folke/snacks.nvim) OR
+- [telescope](https://github.com/nvim-telescope/telescope.nvim) or 
+[snacks.nvim](https://github.com/folke/snacks.nvim) OR
   ([dressing.nvim](http://github.com/stevearc/dressing.nvim) AND
   [fzf-lua](https://github.com/ibhagwan/fzf-lua)).
   * Note that snippet previews only work when using `telescope` or `snacks`.
@@ -310,9 +311,11 @@ require("scissors").setup {
 	},
 }
 ```
-> Note that you can configure the `snacks` picker through `snacks.nvim`'s picker configuration.
-> See the [snacks docs](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md) for more
-> information.
+
+> Note that you can configure the `snacks` picker through `snacks.nvim`'s
+picker configuration. See the
+[snacks docs](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md)
+for more information.
 
 ## Cookbook & FAQ
 

--- a/lua/scissors/2-picker/picker-choice.lua
+++ b/lua/scissors/2-picker/picker-choice.lua
@@ -9,8 +9,11 @@ function M.selectSnippet(allSnippets)
 	-- INFO not using ternary to pass variable into `require`, since that
 	-- prevents the LSP from picking up references
 	local hasTelescope, _ = pcall(require, "telescope")
+	local hasSnacks, _ = pcall(require, "snacks")
 	if hasTelescope then
 		require("scissors.2-picker.telescope").selectSnippet(allSnippets, prompt)
+	elseif hasSnacks then
+		require("scissors.2-picker.snacks").selectSnippet(allSnippets, prompt)
 	else
 		require("scissors.2-picker.vim-ui-select").selectSnippet(allSnippets, prompt)
 	end

--- a/lua/scissors/2-picker/snacks.lua
+++ b/lua/scissors/2-picker/snacks.lua
@@ -1,0 +1,65 @@
+-- DOCS https://github.com/folke/snacks.nvim/blob/main/docs/picker.md#-module
+--------------------------------------------------------------------------------
+local M = {}
+
+local edit = require("scissors.3-edit-popup")
+local u = require("scissors.utils")
+--------------------------------------------------------------------------------
+
+---@param snippets Scissors.SnippetObj[]
+---@return Scissors.SnacksObj[]
+local function createSnacksItems(snippets)
+	---@type Scissors.SnacksObj[]
+	local items = {}
+	for i, snip in ipairs(snippets) do
+		local filename = vim.fs.basename(snip.fullPath):gsub("%.json$", "")
+		local displayName = u.snipDisplayName(snip)
+		local name = displayName .. "\t" .. filename
+
+		table.insert(items, {
+			idx = i,
+			score = i,
+			text = displayName .. " " .. table.concat(snip.body, "\n"),
+			name = name,
+			snippet = snip,
+			displayName = displayName,
+		})
+
+		table.sort(items, function(a, b) return a.name < b.name end)
+	end
+
+	return items
+end
+
+---@param snippets Scissors.SnippetObj[] entries
+---@param prompt string
+function M.selectSnippet(snippets, prompt)
+	return Snacks.picker {
+		prompt = prompt,
+		items = createSnacksItems(snippets),
+		---@param item Scissors.SnacksObj
+		format = function(item, _)
+			local ret = {}
+			ret[#ret + 1] = { item.displayName, "SnacksPickerFile" }
+			ret[#ret + 1] = { " " }
+			ret[#ret + 1] = { "[" .. item.snippet.filetype .. "]", "@comment" }
+			return ret
+		end,
+		preview = function(ctx)
+			local snip = ctx.item.snippet
+			local bufnr = ctx.buf
+			vim.bo[bufnr].modifiable = true
+			vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, snip.body)
+			vim.bo[bufnr].filetype = snip.filetype
+			vim.defer_fn(function() u.tokenHighlight(bufnr) end, 1)
+		end,
+		---@param item Scissors.SnacksObj,
+		confirm = function(picker, item)
+			picker:close()
+			if item then edit.editInPopup(item.snippet, "update") end
+		end,
+	}
+end
+
+--------------------------------------------------------------------------------
+return M

--- a/lua/scissors/2-picker/snacks.lua
+++ b/lua/scissors/2-picker/snacks.lua
@@ -34,7 +34,7 @@ end
 ---@param snippets Scissors.SnippetObj[] entries
 ---@param prompt string
 function M.selectSnippet(snippets, prompt)
-	return Snacks.picker {
+	return require("snacks").picker {
 		prompt = prompt,
 		items = createSnacksItems(snippets),
 		---@param item Scissors.SnacksObj
@@ -46,6 +46,7 @@ function M.selectSnippet(snippets, prompt)
 			return ret
 		end,
 		preview = function(ctx)
+			---@type Scissors.SnippetObj
 			local snip = ctx.item.snippet
 			local bufnr = ctx.buf
 			vim.bo[bufnr].modifiable = true

--- a/lua/scissors/2-picker/snacks.lua
+++ b/lua/scissors/2-picker/snacks.lua
@@ -46,9 +46,8 @@ function M.selectSnippet(snippets, prompt)
 			return ret
 		end,
 		preview = function(ctx)
-			---@type Scissors.SnippetObj
-			local snip = ctx.item.snippet
-			local bufnr = ctx.buf
+			local snip = ctx.item.snippet ---@type Scissors.SnippetObj
+			local bufnr = ctx.buf ---@type number
 			vim.bo[bufnr].modifiable = true
 			vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, snip.body)
 			vim.bo[bufnr].filetype = snip.filetype

--- a/lua/scissors/types.lua
+++ b/lua/scissors/types.lua
@@ -1,9 +1,12 @@
 ---@meta
 
----@class Scissors.SnacksObj: snacks.picker.Item
+---@class Scissors.SnacksObj
+---@field idx integer
+---@field score integer
+---@field text string
+---@field name string
 ---@field snippet Scissors.SnippetObj
 ---@field displayName string
----@field name string
 
 ---@class Scissors.snipFile
 ---@field path string

--- a/lua/scissors/types.lua
+++ b/lua/scissors/types.lua
@@ -1,5 +1,9 @@
 ---@meta
 
+---@class Scissors.SnacksObj: snacks.picker.Item
+---@field snippet Scissors.SnippetObj
+---@field displayName string
+
 ---@class Scissors.snipFile
 ---@field path string
 ---@field ft string

--- a/lua/scissors/types.lua
+++ b/lua/scissors/types.lua
@@ -3,6 +3,7 @@
 ---@class Scissors.SnacksObj: snacks.picker.Item
 ---@field snippet Scissors.SnippetObj
 ---@field displayName string
+---@field name string
 
 ---@class Scissors.snipFile
 ---@field path string


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).

## Configuration
I chose not to expose `snacks` configuration options through the `nvim-scissors` config. It's possible to style the picker entirely through the `snacks` configuration. This information is mentioned in the `README`. I also chose not to implement the `addSnippet` function for `snacks`. Similar to `dressing.nvim`, `snacks` overrides `vim.ui.select` and can be modified through the `snacks` configuration.

Default `snacks` and `nvim-scissors` settings
![2025-03-12-173414_hyprshot](https://github.com/user-attachments/assets/c5ff412d-ca67-497a-adaf-e6193fba4ad8)

Modified `snacks` settings w/ default `nvim-scissors` settings
![2025-03-12-174747_hyprshot](https://github.com/user-attachments/assets/2ddf718d-0fac-4fb2-9807-63cacef1e3b4)





## Considerations
There is an edge case where a user could have both `telescope` and `snacks` installed. Right now `telescope` gets used since it's the first condition checked. It might make sense to add a configuration option to let the user pick their preferred picker. A simple string literal union of `---@type "telescope"|"snacks"` would solve that issue.