### PR TITLE
fix(backdrop): do not create a border with vim.o.winborder

### DIFF
--- a/lua/scissors/backdrop.lua
+++ b/lua/scissors/backdrop.lua
@@ -24,6 +24,7 @@ function M.new(referenceBuf, referenceZindex)
 		width = vim.o.columns,
 		height = vim.o.lines,
 		focusable = false,
+		border = "none",
 		style = "minimal",
 		zindex = referenceZindex - 1, -- ensure it's below the reference window
 	})


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).

## Description

Hi, if `vim.o.winborder` is set, it will create a border for window backdrop which looks a bit weird, so i set `border = "none"`

without `border = "none"` and `vim.o.winborder = "rounded"`:
![20250323_14h41m13s_grim](https://github.com/user-attachments/assets/6e46d683-d008-451f-8c7f-4fb03379ca5f)

with `border = "none"` and `vim.o.winborder = "rounded"`:
![20250323_14h40m49s_grim](https://github.com/user-attachments/assets/fea411a5-9b30-4dd1-ae34-f844418e5c68)

