### PR TITLE
feat: fzf-lua integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,15 @@ Automagical editing and creation of snippets.
 - nvim 0.10+
 - Snippets saved in the [VSCode-style snippet
   format](#introduction-to-the-vscode-style-snippet-format).
-- *Recommended*: [telescope](https://github.com/nvim-telescope/telescope.nvim)
-  OR [snacks.nvim](https://github.com/folke/snacks.nvim). Without one of them,
-  the plugin falls back to `vim.ui.select`, which still works but lacks search
-  and snippet previews.
+- *Recommended*:
+    - *ONE* of the following pickers:
+        - [telescope](https://github.com/nvim-telescope/telescope.nvim)
+        - [snacks.nvim](https://github.com/folke/snacks.nvim)
+        - [fzf-lua](https://github.com/ibhagwan/fzf-lua)
+
+        Without one of them, the plugin falls back to `vim.ui.select`, which still works but lacks
+        search and snippet previews.
+
 - A snippet engine that can load VS Code-style snippets, such as:
     - [LuaSnip](https://github.com/L3MON4D3/LuaSnip)
     - [mini.snippets](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-snippets.md)
@@ -101,17 +106,19 @@ Automagical editing and creation of snippets.
 -- lazy.nvim
 {
 	"chrisgrieser/nvim-scissors",
-	dependencies = "folke/snacks.nvim", -- either snacks or telescope
-   -- dependencies = "nvim-telescope/telescope.nvim",
+	dependencies = "folke/snacks.nvim", -- either snacks, fzf-lua, telescope
+	  -- dependencies = "ibhagwan/fzf-lua",
+	  -- dependencies = "nvim-telescope/telescope.nvim",
 	opts = {
 		snippetDir = "path/to/your/snippetFolder",
-	} 
+	}
 },
 
 -- packer
 use {
 	"chrisgrieser/nvim-scissors",
-	dependencies = "folke/snacks.nvim", -- either snacks or telescope
+	dependencies = "folke/snacks.nvim", -- either snacks, fzf-lua, telescope
+	  -- dependencies = "ibhagwan/fzf-lua",
 	  -- dependencies = "nvim-telescope/telescope.nvim",
 	config = function()
 		require("scissors").setup ({

--- a/README.md
+++ b/README.md
@@ -285,6 +285,26 @@ require("scissors").setup {
 	snippetSelection = {
 		picker = "auto", ---@type "auto"|"telescope"|"snacks"|"vim.ui.select"
 
+		fzfLua = {
+			-- same format as fzf_opts in `:h fzf-lua-customization`
+			fzf_opts = {},
+
+			-- suppress warnings from fzf-lua.
+			-- This is true by default, since commonly-used fzf-lua presets
+			-- create warnings due to border settings.
+			silent = true,
+
+			-- same format as winopts in `:h fzf-lua-customization`
+			--- @type fzf-lua.config.Winopts
+			winopts = {
+				preview = {
+					hidden = false,
+					--- @diagnostic disable-next-line missing-fields
+					winopts = {},
+				},
+			},
+		},
+
 		telescope = {
 			-- By default, the query only searches snippet prefixes. Set this to
 			-- `true` to also search the body of the snippets.

--- a/README.md
+++ b/README.md
@@ -302,12 +302,9 @@ require("scissors").setup {
 			silent = true,
 
 			-- same format as winopts in `:h fzf-lua-customization`
-			--- @type fzf-lua.config.Winopts
 			winopts = {
 				preview = {
 					hidden = false,
-					--- @diagnostic disable-next-line missing-fields
-					winopts = {},
 				},
 			},
 		},
@@ -327,7 +324,7 @@ require("scissors").setup {
 			},
 		},
 
-		-- `snacks` picker configurable via snacks config, 
+		-- `snacks` picker configurable via snacks config,
 		-- see https://github.com/folke/snacks.nvim/blob/main/docs/picker.md
 	},
 

--- a/doc/nvim-scissors.txt
+++ b/doc/nvim-scissors.txt
@@ -317,8 +317,28 @@ The `.setup()` call is optional.
         },
     
         snippetSelection = {
-            picker = "auto", ---@type "auto"|"telescope"|"snacks"|"vim.ui.select"
-    
+            picker = "auto", ---@type "auto"|"fzf-lua"|"telescope"|"snacks"|"vim.ui.select"
+
+	    fzfLua = {
+		-- same format as fzf_opts in `:h fzf-lua-customization`
+		fzf_opts = {},
+
+		-- suppress warnings from fzf-lua.
+		-- This is true by default, since commonly-used fzf-lua presets
+		-- create warnings due to border settings.
+		silent = true,
+
+		-- same format as winopts in `:h fzf-lua-customization`
+		--- @type fzf-lua.config.Winopts
+		winopts = {
+		    preview = {
+			hidden = false,
+			--- @diagnostic disable-next-line missing-fields
+			winopts = {},
+		    },
+		},
+	    },
+
             telescope = {
                 -- By default, the query only searches snippet prefixes. Set this to
                 -- `true` to also search the body of the snippets.

--- a/doc/nvim-scissors.txt
+++ b/doc/nvim-scissors.txt
@@ -335,11 +335,8 @@ The `.setup()` call is optional.
 		silent = true,
 
 		-- same format as winopts in `:h fzf-lua-customization`
-		--- @type fzf-lua.config.Winopts
 		winopts = {
 		    preview = {
-			hidden = false,
-			--- @diagnostic disable-next-line missing-fields
 			winopts = {},
 		    },
 		},

--- a/doc/nvim-scissors.txt
+++ b/doc/nvim-scissors.txt
@@ -69,7 +69,7 @@ FEATURES                               *nvim-scissors-nvim-scissors--features*
 - Automatic hot-reloading of any changes, so you do not have to restart nvim for
     changes to take effect.
 - Optional JSON-formatting and sorting of the snippet file. (|nvim-scissors-useful-when-version-controlling-your-snippet-collection|.)
-- Snippet/file selection via `telescope`, `snacks`, or `vim.ui.select`.
+- Snippet/file selection via `telescope`, `snacks`, `fzf-lua`, or `vim.ui.select`.
 - Automatic bootstrapping of the snippet folder or new snippet files if needed.
 - Supports only VSCode-style
     snippets <https://code.visualstudio.com/docs/editor/userdefinedsnippets#_create-your-own-snippets>.
@@ -95,10 +95,14 @@ REQUIREMENTS                       *nvim-scissors-nvim-scissors--requirements*
 
 - nvim 0.10+
 - Snippets saved in the |nvim-scissors-vscode-style-snippet-format|.
-- _Recommended_: telescope <https://github.com/nvim-telescope/telescope.nvim>
-    OR snacks.nvim <https://github.com/folke/snacks.nvim>. Without one of them,
-    the plugin falls back to `vim.ui.select`, which still works but lacks search
-    and snippet previews.
+- _Recommended_:
+  - _ONE_ of the following pickers:
+    - telescope <https://github.com/nvim-telescope/telescope.nvim>
+    - snacks.nvim <https://github.com/folke/snacks.nvim>
+    - fzf-lua <https://github.com/ibhagwan/fzf-lua>
+
+    Without one of them, the plugin falls back to `vim.ui.select`, which still
+    works but lacks search and snippet previews.
 - A snippet engine that can load VS Code-style snippets, such as:
     - LuaSnip <https://github.com/L3MON4D3/LuaSnip>
     - mini.snippets <https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-snippets.md>
@@ -119,18 +123,20 @@ NVIM-SCISSORS ~
 >lua
     -- lazy.nvim
     {
-        "chrisgrieser/nvim-scissors",
-        dependencies = "folke/snacks.nvim", -- either snacks or telescope
-       -- dependencies = "nvim-telescope/telescope.nvim",
-        opts = {
-            snippetDir = "path/to/your/snippetFolder",
-        } 
+	"chrisgrieser/nvim-scissors",
+	dependencies = "folke/snacks.nvim", -- either snacks, fzf-lua, telescope
+	  -- dependencies = "ibhagwan/fzf-lua",
+	  -- dependencies = "nvim-telescope/telescope.nvim",
+	opts = {
+	    snippetDir = "path/to/your/snippetFolder",
+	}
     },
-    
+
     -- packer
     use {
         "chrisgrieser/nvim-scissors",
-        dependencies = "folke/snacks.nvim", -- either snacks or telescope
+        dependencies = "folke/snacks.nvim", -- either snacks, fzf-lua, telescope
+          -- dependencies = "ibhagwan/fzf-lua",
           -- dependencies = "nvim-telescope/telescope.nvim",
         config = function()
             require("scissors").setup ({

--- a/lua/scissors/2-picker/fzf-lua.lua
+++ b/lua/scissors/2-picker/fzf-lua.lua
@@ -1,0 +1,108 @@
+-- DOCS https://github.com/folke/snacks.nvim/blob/main/docs/picker.md#-module
+--------------------------------------------------------------------------------
+local M = {}
+
+local u = require("scissors.utils")
+--------------------------------------------------------------------------------
+
+--- an implementation of the fzf-lua previewer api which shows snippet bodies.
+--- @class Snacks.FzfLuaSnippetPreviewer : fzf-lua.config.Previewer, fzf-lua.previewer.Builtin
+--- @field super fzf-lua.previewer.Builtin the Builtin class
+--- @see <https://github.com/ibhagwan/fzf-lua/wiki/Advanced#neovim-builtin-preview>
+local SnippetPreviewer = require("fzf-lua.previewer.builtin").base:extend()
+
+--- creates a new instance of the snippet previewer class.
+--- part of fzf-lua's previewer api.
+---@param o table
+---@param opts table
+---@return fzf-lua.previewer.Builtin
+function SnippetPreviewer:new(o, opts, fzf_win)
+	SnippetPreviewer.super.new(self, o, opts, fzf_win)
+	setmetatable(self, SnippetPreviewer)
+	return self
+end
+
+--- populates a temporary buffer with the contents of the given snippet's body.
+--- the contents of the buffer are highlighted.
+---@param displayName string of the snippet to preview
+function SnippetPreviewer:populate_preview_buf(displayName)
+	local snip = self.opts.scissorsSnippetsByDisplayName[displayName]
+
+	local tmpbuf = self:get_tmp_buffer()
+	vim.api.nvim_buf_set_lines(tmpbuf, 0, -1, false, snip.body)
+
+	--- @type vim.api.keyset.option
+	local setOpts = { buf = tmpbuf }
+
+	local filetype = snip.filetype == "all" and "text" or snip.filetype
+	vim.api.nvim_set_option_value('filetype', filetype, setOpts)
+	vim.api.nvim_set_option_value('modifiable', false, setOpts)
+	vim.defer_fn(function() u.tokenHighlight(tmpbuf) end, 1)
+
+	self:set_preview_buf(tmpbuf)
+	self.win:update_preview_scrollbar()
+end
+
+--- creates a function which fzf will use to populate the list of
+--- available snippets.
+---
+--- when the function is called, it will populate a cache of
+--- display names for each snippet. This cache is typically re-used
+--- by the FzfLuaSnippetPreviewer.
+---
+--- @param snippets Scissors.SnippetObj
+--- @return { [string]: Scissors.SnippetObj } snippetsByDisplayName
+--- @return fun(cb: fzf-lua.fzfCb) setContents
+local function createContentSetter(snippets)
+	local snippetsByDisplayName = {}
+
+	--- @param cb fzf-lua.fzfCb
+	local function setContents(cb)
+		local co = coroutine.running()
+		local function resume() coroutine.resume(co) end
+
+		for _, snip in ipairs(snippets) do
+			local displayName = u.snipDisplayName(snip)
+
+			snippetsByDisplayName[displayName] = snip
+			cb(displayName, resume)
+			coroutine.yield()
+		end
+
+		-- signal EOF to fzf and close the named pipe
+		cb()
+	end
+
+	return snippetsByDisplayName, coroutine.wrap(setContents)
+end
+
+---@param snippets Scissors.SnippetObj[] entries
+---@param prompt string
+function M.selectSnippet(snippets, prompt)
+	local fzf = require('fzf-lua')
+	local conf = require("scissors.config").config.snippetSelection.fzfLua
+
+	local snippetsByDisplayName, setContents = createContentSetter(snippets)
+	fzf.fzf_exec(setContents, {
+		prompt = prompt,
+		previewer = SnippetPreviewer,
+		actions = {
+			['default'] = function(selected, _)
+				local snip = snippetsByDisplayName[selected[1]]
+				require("scissors.3-edit-popup").editInPopup(snip, "update")
+			end,
+		},
+
+		-- this passes the scissors to the SnippetPreviewer.
+		-- prefixed with "scissors" to hopefully prevent any future clashing
+		scissorsSnippetsByDisplayName = snippetsByDisplayName,
+
+		-- user config
+		fzf_opts = conf.fzf_opts,
+		silent = conf.silent,
+		winopts = conf.winopts,
+	})
+end
+
+--------------------------------------------------------------------------------
+return M

--- a/lua/scissors/2-picker/fzf-lua.lua
+++ b/lua/scissors/2-picker/fzf-lua.lua
@@ -5,17 +5,23 @@ local M = {}
 local u = require("scissors.utils")
 --------------------------------------------------------------------------------
 
---- an implementation of the fzf-lua previewer api which shows snippet bodies.
---- @class Snacks.FzfLuaSnippetPreviewer : fzf-lua.config.Previewer, fzf-lua.previewer.Builtin
---- @field super fzf-lua.previewer.Builtin the Builtin class
---- @see <https://github.com/ibhagwan/fzf-lua/wiki/Advanced#neovim-builtin-preview>
+--- an implementation of the
+--- [fzf-lua](https://github.com/ibhagwan/fzf-lua/wiki/Advanced#neovim-builtin-preview)
+--- previewer api which shows snippet bodies.
+--- @class Scissors.FzfLuaSnippetPreviewer
+--- @field super Scissors.FzfLua.Object the Builtin class
+--- @field opts { [string]: unknown }
+--- @field get_tmp_buffer fun(): integer
+--- @field set_preview_buf fun(self: Scissors.FzfLuaSnippetPreviewer, buf: integer)
+--- @field win Scissors.FzfLua.Win
 local SnippetPreviewer = require("fzf-lua.previewer.builtin").base:extend()
 
 --- creates a new instance of the snippet previewer class.
 --- part of fzf-lua's previewer api.
 ---@param o table
 ---@param opts table
----@return fzf-lua.previewer.Builtin
+---@param fzf_win unknown
+---@return Scissors.FzfLuaSnippetPreviewer
 function SnippetPreviewer:new(o, opts, fzf_win)
 	SnippetPreviewer.super.new(self, o, opts, fzf_win)
 	setmetatable(self, SnippetPreviewer)

--- a/lua/scissors/2-picker/picker-choice.lua
+++ b/lua/scissors/2-picker/picker-choice.lua
@@ -8,11 +8,14 @@ function M.selectSnippet(allSnippets)
 	local picker = require("scissors.config").config.snippetSelection.picker
 	local hasTelescope, _ = pcall(require, "telescope")
 	local hasSnacks, _ = pcall(require, "snacks")
+	local hasFzfLua, _ = pcall(require, "fzf-lua")
 
 	if picker == "telescope" or (picker == "auto" and hasTelescope) then
 		require("scissors.2-picker.telescope").selectSnippet(allSnippets, prompt)
 	elseif picker == "snacks" or (picker == "auto" and hasSnacks) then
 		require("scissors.2-picker.snacks").selectSnippet(allSnippets, prompt)
+	elseif picker == "fzf-lua" or (picker == "auto" and hasFzfLua) then
+		require("scissors.2-picker.fzf-lua").selectSnippet(allSnippets, prompt)
 	else
 		require("scissors.2-picker.vim-ui-select").selectSnippet(allSnippets, prompt)
 	end

--- a/lua/scissors/config.lua
+++ b/lua/scissors/config.lua
@@ -46,12 +46,9 @@ local defaultConfig = {
 			silent = true,
 
 			-- same format as winopts in `:h fzf-lua-customization`
-			--- @type fzf-lua.config.Winopts
 			winopts = {
 				preview = {
 					hidden = false,
-					--- @diagnostic disable-next-line missing-fields
-					winopts = {},
 				},
 			},
 		},

--- a/lua/scissors/config.lua
+++ b/lua/scissors/config.lua
@@ -32,7 +32,29 @@ local defaultConfig = {
 		},
 	},
 	snippetSelection = {
-		picker = "auto", ---@type "auto"|"telescope"|"snacks"|"vim.ui.select"
+		picker = "auto", ---@type "auto"|"fzf-lua"|"telescope"|"snacks"|"vim.ui.select"
+
+		--- @module 'fzf-lua'
+
+		fzfLua = {
+			-- same format as fzf_opts in `:h fzf-lua-customization`
+			fzf_opts = {},
+
+			-- suppress warnings from fzf-lua.
+			-- This is true by default, since commonly-used fzf-lua presets
+			-- create warnings due to border settings.
+			silent = true,
+
+			-- same format as winopts in `:h fzf-lua-customization`
+			--- @type fzf-lua.config.Winopts
+			winopts = {
+				preview = {
+					hidden = false,
+					--- @diagnostic disable-next-line missing-fields
+					winopts = {},
+				},
+			},
+		},
 
 		telescope = {
 			-- By default, the query only searches snippet prefixes. Set this to

--- a/lua/scissors/types.lua
+++ b/lua/scissors/types.lua
@@ -37,3 +37,9 @@
 ---@field prefix string|string[]
 ---@field body string|string[]
 ---@field description? string
+
+---@class Scissors.FzfLua.Object
+---@field new fun(self: table, o: table, opts: table, fzf_win?: unknown)
+
+---@class Scissors.FzfLua.Win
+---@field update_preview_scrollbar fun(self: Scissors.FzfLua.Win)


### PR DESCRIPTION
Firstly, thank you for this plugin! I use it very frequently to create snippets while working.

## Problem statement

I see that this plugin has integrations with a couple popular pickers, but not
[fzf-lua](https://github.com/ibhagwan/fzf-lua), which is what I use. 

Since fzf-lua does have an implementation of `vim.ui.select`, this plugin is still technically
compatible. However, using it this way means there is no preview in the snippet selector.

## Proposed solution

This MR adds a direct integration with fzf-lua, and used the previous snacks.nvim integration as a reference.

## AI usage disclosure

This MR was created without AI.

## Checklist

- [x] Variable names follow `camelCase` convention.
    - fzf requires some function / field names to be in snake_case, but I tried to use camelCase as
      much as possible.
- [x] All AI-generated code has been reviewed by a human.
- [x] The `README.md` has been updated for any new or modified functionality
      (the `.txt` file is auto-generated and does not need to be modified).
    - I updated the .txt file by hand... oops! I can revert that if it is a problem.

I also tried to stay consistent with tabs vs spaces, though I saw some files had a mix of both... if I did the wrong thing somewhere, please let me know.